### PR TITLE
document option jdk in basic usage

### DIFF
--- a/user/languages/java.md
+++ b/user/languages/java.md
@@ -20,6 +20,13 @@ To use the Java environment add the following to your `.travis.yml`:
 language: java
 ```
 
+If you want to use a JDK other than the default (Oracle JDK 7) add the option `jdk`:
+
+```yaml
+language: java
+jdk: oraclejdk8
+```
+
 ## Projects Using Maven
 
 ### Default script Command
@@ -46,7 +53,7 @@ Before running the build, Travis CI installs dependencies:
 
 ```bash
 mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
-```
+```jdk
 
 or if your project uses the `mvnw` wrapper script:
 

--- a/user/languages/java.md
+++ b/user/languages/java.md
@@ -53,7 +53,7 @@ Before running the build, Travis CI installs dependencies:
 
 ```bash
 mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
-```jdk
+```
 
 or if your project uses the `mvnw` wrapper script:
 


### PR DESCRIPTION
`jdk` is only mentioned in "Testing Against Multiple JDKs". Nowadays it is probably a very common usage to switch to JDK8.